### PR TITLE
Update translation: 'Living' -> 'Live'.

### DIFF
--- a/src/popup/i18n/locales/en.json5
+++ b/src/popup/i18n/locales/en.json5
@@ -79,7 +79,7 @@
       },
       // Lives that are undergoing
       current: {
-        label: "Living",
+        label: "Live",
         loading: "Loading current lives",
       },
       // Lives that are scheduled to perform


### PR DESCRIPTION
This pr adopts translation suggestions from #22.