### PR TITLE
Fix ended lives order

### DIFF
--- a/src/background/workflows/index.js
+++ b/src/background/workflows/index.js
@@ -74,7 +74,7 @@ const syncCurrentLives = async () => {
   console.log(`[syncLives]Badge text has been set to ${lives.length}`)
 
   // Subscription is simplified cause here is the only mutation of currentLives
-  const endedLives = [...(getCachedEndedLives() ?? [])]
+  const endedLives = getCachedEndedLives() ?? []
   const newEndedLives = differenceBy((getCachedCurrentLives() ?? []), lives, 'id').map(live => ({
     ...live,
     duration: moment().diff(moment(live['start_at']), 'seconds'),

--- a/src/background/workflows/index.test.js
+++ b/src/background/workflows/index.test.js
@@ -172,78 +172,120 @@ test('should get cached current lives', async () => {
 
 test('should sync current lives', async () => {
   Date.now = jest.fn(() => unixTime * 1000)
+
   // First run
   const currentLivesOne = [
     {
       id: 1,
       start_at: moment().subtract(3, 'hours').toISOString(),
-      duration: 0,
+      duration: null,
     },
     {
       id: 2,
+      start_at: moment().subtract(3, 'hours').toISOString(),
+      duration: null,
+    },
+    {
+      id: 3,
       start_at: moment().subtract(2, 'hours').toISOString(),
-      duration: 0,
+      duration: null,
     },
   ]
+  const endedLivesOne = []
+
   getCurrentLives.mockResolvedValueOnce(currentLivesOne)
 
   const returnValueOne = await workflows.syncCurrentLives()
 
   expect(browser.browserAction.setBadgeText).toHaveBeenCalledTimes(1)
-  expect(browser.browserAction.setBadgeText).toHaveBeenCalledWith({ text: '2' })
+  expect(browser.browserAction.setBadgeText).toHaveBeenCalledWith({ text: '3' })
   expect(store.data[CURRENT_LIVES]).toEqual(currentLivesOne)
-  expect(store.data[ENDED_LIVES]).toEqual(undefined)
+  expect(store.data[ENDED_LIVES]).toEqual(endedLivesOne)
   expect(returnValueOne).toEqual(currentLivesOne)
-  // Second run
+
   getCurrentLives.mockClear()
   browser.browserAction.setBadgeText.mockClear()
+
+  // Second run
   const currentLivesTwo = [
     currentLivesOne[1],
+    currentLivesOne[2],
     {
-      id: 3,
+      id: 4,
       start_at: moment().subtract(1, 'hours').toISOString(),
-      duration: 0,
+      duration: null,
     },
   ]
+  const endedLivesTwo = [
+    {
+      ...currentLivesOne[0],
+      duration: moment.duration(3, 'hours').as('seconds'),
+    },
+  ]
+
   getCurrentLives.mockResolvedValueOnce(currentLivesTwo)
 
   const returnValueTwo = await workflows.syncCurrentLives()
 
   expect(browser.browserAction.setBadgeText).toHaveBeenCalledTimes(1)
-  expect(browser.browserAction.setBadgeText).toHaveBeenCalledWith({ text: '2' })
+  expect(browser.browserAction.setBadgeText).toHaveBeenCalledWith({ text: '3' })
   expect(store.data[CURRENT_LIVES]).toEqual(currentLivesTwo)
-  expect(store.data[ENDED_LIVES]).toEqual([
-    {
-      ...currentLivesOne[0],
-      duration: moment.duration(3, 'hours').as('seconds'),
-    },
-  ])
+  expect(store.data[ENDED_LIVES]).toEqual(endedLivesTwo)
   expect(returnValueTwo).toEqual(currentLivesTwo)
-  // Third run
+
   getCurrentLives.mockClear()
   browser.browserAction.setBadgeText.mockClear()
-  const currentLivesThree = []
+
+  // Third run
+  const currentLivesThree = [
+    currentLivesTwo[0],
+    currentLivesTwo[2],
+  ]
+  const endedLivesThree = [
+    endedLivesTwo[0],
+    {
+      ...currentLivesOne[2],
+      duration: moment.duration(2, 'hours').as('seconds'),
+    },
+  ]
+
   getCurrentLives.mockResolvedValueOnce(currentLivesThree)
 
   const returnValueThree = await workflows.syncCurrentLives()
 
   expect(browser.browserAction.setBadgeText).toHaveBeenCalledTimes(1)
-  expect(browser.browserAction.setBadgeText).toHaveBeenCalledWith({ text: '0' })
+  expect(browser.browserAction.setBadgeText).toHaveBeenCalledWith({ text: '2' })
   expect(store.data[CURRENT_LIVES]).toEqual(currentLivesThree)
-  expect(store.data[ENDED_LIVES]).toEqual([
+  expect(store.data[ENDED_LIVES]).toEqual(endedLivesThree)
+  expect(returnValueThree).toEqual(currentLivesThree)
+
+  getCurrentLives.mockClear()
+  browser.browserAction.setBadgeText.mockClear()
+
+  // Fourth run
+  const currentLivesFour = []
+  const endedLivesFour = [
+    endedLivesThree[0],
     {
-      ...currentLivesOne[0],
+      ...currentLivesThree[0],
       duration: moment.duration(3, 'hours').as('seconds'),
     },
+    endedLivesThree[1],
     {
-      ...currentLivesOne[1],
-      duration: moment.duration(2, 'hours').as('seconds'),
-    }, {
-      ...currentLivesTwo[1],
+      ...currentLivesThree[1],
       duration: moment.duration(1, 'hours').as('seconds'),
     },
-  ])
-  expect(returnValueThree).toEqual(currentLivesThree)
+  ]
+
+  getCurrentLives.mockResolvedValueOnce(currentLivesFour)
+
+  const returnValueFour = await workflows.syncCurrentLives()
+
+  expect(browser.browserAction.setBadgeText).toHaveBeenCalledTimes(1)
+  expect(browser.browserAction.setBadgeText).toHaveBeenCalledWith({ text: '0' })
+  expect(store.data[CURRENT_LIVES]).toEqual(currentLivesFour)
+  expect(store.data[ENDED_LIVES]).toEqual(endedLivesFour)
+  expect(returnValueFour).toEqual(currentLivesFour)
 })
 
 test('should get cached scheduled lives', async () => {

--- a/src/popup/components/live-list-ended.vue
+++ b/src/popup/components/live-list-ended.vue
@@ -47,8 +47,13 @@
       this.savedScrollTop = this.parentElement.scrollTop
     },
     updated() {
-      const newScrollTop = this.savedScrollTop
-        + (this.parentElement.scrollHeight - this.savedScrollHeight)
+      const scrollHeightDiff = this.parentElement.scrollHeight - this.savedScrollHeight
+
+      if (scrollHeightDiff === 0) {
+        return
+      }
+
+      const newScrollTop = this.savedScrollTop + scrollHeightDiff
       this.parentElement.scrollTop = newScrollTop
       setTimeout(() => {
         this.parentElement.scrollTo({ top: newScrollTop - 50, behavior: 'smooth' })


### PR DESCRIPTION
This pr expects to fix #25.

#### Propsed changes
  - Respect the order of start_at when moving kives from current to ended.
  - Reduce unnecessary updates of scrollTop when ended lives are updated.