### PR TITLE
Resolve member avatars for notifications on Chrome.

### DIFF
--- a/src/background/notification/index.js
+++ b/src/background/notification/index.js
@@ -2,23 +2,27 @@ import { noop } from 'lodash'
 import browser from 'webextension-polyfill'
 
 const notification = {
-  create(stringId, { title, message, iconUrl, onClick = noop }) {
-    browser.notifications.create(stringId, {
+  async create(stringId, { title, message, iconUrl, onClick = noop }) {
+    await browser.notifications.create(stringId, {
       type: 'basic',
       title,
       message,
-      iconUrl,
-    }).catch(
-      // Icon from the web will not be loaded successfully in Chrome
-      () => browser.notifications.create(stringId, {
-        type: 'basic',
-        title,
-        message,
-        iconUrl: browser.runtime.getURL('assets/default_avatar.png'),
-      }),
-    ).then(
-      () => console.log('Successfully created a notification'),
-    )
+      // Icon directly from the web will not be loaded successfully in Chrome
+      // So we load it manually
+      iconUrl: await fetch(iconUrl)
+        .then(response => response.blob())
+        .then(blob => new Promise((resolve, reject) => {
+          const reader = new FileReader()
+          reader.onloadend = () => resolve(reader.result)
+          reader.onerror = reject
+          reader.readAsDataURL(blob)
+        }))
+        .catch(err => {
+          console.log('Failed to download icon', err.message)
+          return browser.runtime.getURL('assets/default_avatar.png')
+        }),
+    })
+    console.log('Successfully created a notification')
 
     const handleClicked = notificationId => {
       if (notificationId !== stringId) return


### PR DESCRIPTION
Field `iconUrl` used to create a desktop notification in Chrome does not accept an external url. This pull-request preload the image and use the base64 data to create the notification. Icon for HoloSchedule is used as a fallback image.