### PR TITLE
Break CJK words anywhere.

### DIFF
--- a/src/popup/components/live-item.vue
+++ b/src/popup/components/live-item.vue
@@ -270,6 +270,7 @@
     font-size: 14px;
     text-overflow: ellipsis;
     word-break: break-all;
+    line-break: anywhere;
     -webkit-box-orient: vertical;
     -webkit-line-clamp: 2;
   }


### PR DESCRIPTION
Special lines of CJK words with extra-rare punctuation usages may cause unwant line breaks when displaying a live's title.
![3](https://user-images.githubusercontent.com/23452609/109393937-64819500-795f-11eb-83f5-43f51d71edbd.png)

This pull-request resolves this issue.
![4](https://user-images.githubusercontent.com/23452609/109393949-706d5700-795f-11eb-9690-65015ebea772.png)
