### PR TITLE
Update calendar formats for sameElse.

### DIFF
--- a/src/popup/i18n/locales/en.json5
+++ b/src/popup/i18n/locales/en.json5
@@ -127,12 +127,12 @@
       // A token string representing the format when displaying datetime with dayjs.
       // You are encouraged to adjust the text wrapped in '[' and ']' or its position.
       // See also: https://day.js.org/docs/display/format
-      sameDay: "[Today at ]H:mm A",
-      nextDay: "[Tomorrow ]H:mm A",
-      nextWeek: "dddd[ at ]H:mm A",
-      lastDay: "[Yesterday ]H:mm A",
+      sameDay: "[Today at] H:mm A",
+      nextDay: "[Tomorrow] H:mm A",
+      nextWeek: "dddd [at] H:mm A",
+      lastDay: "[Yesterday] H:mm A",
       lastWeek: "[Last] dddd H:mm A",
-      sameElse: "DD/MM/YYYY H:mm A"
+      sameElse: "MMM Do [at] H:mm A"
     },
     // Display the start time of this live
     startAt: {

--- a/src/popup/i18n/locales/ja.json5
+++ b/src/popup/i18n/locales/ja.json5
@@ -132,7 +132,7 @@
       nextWeek: "dddd A H:mm",
       lastDay: "[昨日]A H:mm",
       lastWeek: "[先週] dddd A H:mm",
-      sameElse: "DD/MM/YYYY A H:mm"
+      sameElse: "MMMDo A H:mm"
     },
     // Display the start time of this live
     startAt: {

--- a/src/popup/i18n/locales/zh-CN.json5
+++ b/src/popup/i18n/locales/zh-CN.json5
@@ -132,7 +132,7 @@
       nextWeek: "dddd A H:mm",
       lastDay: "[昨天]A H:mm",
       lastWeek: "[上周] dddd A H:mm",
-      sameElse: "DD/MM/YYYY A H:mm"
+      sameElse: "MMMDo A H:mm"
     },
     // Display the start time of this live
     startAt: {


### PR DESCRIPTION
In rare cases, date part of a scheduled live is not displayed in the desired form. This is caused by field `sameElse` which is not set properly.
![5](https://user-images.githubusercontent.com/23452609/109394159-82032e80-7960-11eb-94ba-b00d010d5a2f.png)


This pull-request resolves this issue.
![6](https://user-images.githubusercontent.com/23452609/109394161-84fe1f00-7960-11eb-9776-b992cee26d9a.png)
