### PR TITLE
Update colors and brightness in dark mode.

### DIFF
--- a/src/shared/global.less
+++ b/src/shared/global.less
@@ -57,17 +57,17 @@ ul, ol {
   --brightness: 1;
 
   @media (prefers-color-scheme: dark) {
-    --color-bg-base-expand: 0, 0%, 15%;
-    --color-bg-light: hsl(0, 0%, 22%);
-    --color-bg-normal: hsl(0, 0%, 30%);
-    --color-bd: hsl(0, 0%, 30%);
-    --color-text-dark: hsl(0, 0%, 75%);
-    --color-text-normal: hsl(0, 0%, 65%);
-    --color-text-light: hsl(0, 0%, 55%);
+    --color-bg-base-expand: 228, 2%, 23%;
+    --color-bg-light: hsl(228, 2%, 25%);
+    --color-bg-normal: hsl(228, 2%, 28%);
+    --color-bd: hsl(228, 2%, 35%);
+    --color-text-dark: hsl(0, 0%, 95%);
+    --color-text-normal: hsl(0, 0%, 82%);
+    --color-text-light: hsl(0, 0%, 70%);
     --color-text-white: hsl(0, 0%, 100%);
     --color-error: hsl(351, 100%, 32%);
-    --color-theme: hsl(178, 100%, 32%);
+    --color-theme: hsl(178, 100%, 36%);
     --color-white: hsl(0, 0%, 100%);
-    --brightness: .75;
+    --brightness: .92;
   }
 }

--- a/src/shared/global.less
+++ b/src/shared/global.less
@@ -65,7 +65,7 @@ ul, ol {
     --color-text-normal: hsl(0, 0%, 82%);
     --color-text-light: hsl(0, 0%, 70%);
     --color-text-white: hsl(0, 0%, 100%);
-    --color-error: hsl(351, 100%, 32%);
+    --color-error: hsl(351, 100%, 36%);
     --color-theme: hsl(178, 100%, 36%);
     --color-white: hsl(0, 0%, 100%);
     --brightness: .92;


### PR DESCRIPTION
This PR fixes #58.

Overall brightness in dark mode is increased and the contrast between lightest texts and the background is also increased to improve readability.

| Text color | Contrast Before | Contrast After |
| :-----------: | :--------: | :--------: |
| light | [4.50](https://contrast-ratio.com/#hsl%280%2C%200%25%2C%2055%25%29-on-hsl%280%2C%200%25%2C%2015%25%29) | [5.43](https://contrast-ratio.com/#hsl%280%2C%200%25%2C%2070%25%29-on-hsl%28228%2C%202%25%2C%2023%25%29) |
| normal | [6.21](https://contrast-ratio.com/#hsl%280%2C%200%25%2C%2065%25%29-on-hsl%280%2C%200%25%2C%2015%25%29) | [7.45](https://contrast-ratio.com/#hsl%280%2C%200%25%2C%2082%25%29-on-hsl%28228%2C%202%25%2C%2023%25%29) |
| dark | [8.22](https://contrast-ratio.com/#hsl%280%2C%200%25%2C%2075%25%29-on-hsl%280%2C%200%25%2C%2015%25%29) | [10.17](https://contrast-ratio.com/#hsl%280%2C%200%25%2C%2095%25%29-on-hsl%28228%2C%202%25%2C%2023%25%29) |
| theme | [3.65](https://contrast-ratio.com/#hsl%28178%2C%20100%25%2C%2032%25%29-on-hsl%28228%2C%202%25%2C%2023%25%29) | [4.60](https://contrast-ratio.com/#hsl%28178%2C%20100%25%2C%2036%25%29-on-hsl%28228%2C%202%25%2C%2023%25%29) |

Note: A minor brightness decreasement in dark mode is preserved, resulting in images 8% darker than normal.

#### Preview

![0](https://user-images.githubusercontent.com/23452609/111344385-4930bc80-86b7-11eb-847d-c9d0ea913ab3.png)
![1](https://user-images.githubusercontent.com/23452609/111344617-7b421e80-86b7-11eb-90bc-3c8a44e38f4f.png)

#### Comparasion

![8](https://user-images.githubusercontent.com/23452609/111995106-854e9c00-8b53-11eb-8128-1405f992ff66.png)
