### PR TITLE
Fix flipped order of ended lives

### DIFF
--- a/src/background/workflows/index.js
+++ b/src/background/workflows/index.js
@@ -77,7 +77,7 @@ const syncEndedLives = async () => {
   }))
 
   await store.set({
-    [ENDED_LIVES]: uniqBy([...reverse(lives), ...cashedLives], 'id'),
+    [ENDED_LIVES]: reverse(uniqBy([...reverse(cashedLives), ...lives], 'id')),
   })
 
   return getCachedEndedLives()

--- a/src/background/workflows/index.test.js
+++ b/src/background/workflows/index.test.js
@@ -1,6 +1,5 @@
 import dayjs from 'dayjs'
 import duration from 'dayjs/plugin/duration'
-import { reverse, uniqBy } from 'lodash'
 import {
   getChannels,
   getCurrentLives,
@@ -138,7 +137,7 @@ test('should sync ended lives', async () => {
     { id: 10, start_at: dayjs().subtract(3, 'hour').toISOString() },
     { id: 9, start_at: dayjs().subtract(4, 'hour').toISOString() },
   ]
-  const returnValueExpectedOne = reverse([...endedLivesOne])
+  const returnValueExpectedOne = [endedLivesOne[1], endedLivesOne[0]]
 
   getEndedLives.mockResolvedValueOnce(endedLivesOne)
 
@@ -157,7 +156,7 @@ test('should sync ended lives', async () => {
     { id: 9, start_at: dayjs().subtract(4, 'hour').toISOString() },
     { id: 8, start_at: dayjs().subtract(5, 'hour').toISOString() },
   ]
-  const returnValueExpectedTwo = uniqBy([...reverse([...endedLivesTwo]), ...returnValueExpectedOne], 'id')
+  const returnValueExpectedTwo = [endedLivesTwo[1], ...returnValueExpectedOne]
 
   getEndedLives.mockResolvedValueOnce(endedLivesTwo)
 


### PR DESCRIPTION
Fix the flipped order when ended lives with the same start_at are loaded.