### PR TITLE
Update member group

### DIFF
--- a/src/options/App.vue
+++ b/src/options/App.vue
@@ -51,12 +51,17 @@
       groups() {
         return [
           {
+            name: this.$t('app.groups.newDebuts'),
+            // Dummy ids are specified here to be compatible to new members
+            memberIds: range(72, 82),
+          },
+          {
             name: this.$t('app.groups.hololive'),
-            memberIds: without(range(1, 34), 2),
+            memberIds: [62, ...without(range(1, 34), 2)],
           },
           {
             name: this.$t('app.groups.holostars'),
-            memberIds: range(34, 45),
+            memberIds: [63, ...range(34, 45)],
           },
           {
             name: this.$t('app.groups.inonakaMusic'),
@@ -68,16 +73,11 @@
           },
           {
             name: this.$t('app.groups.hololiveIndonesia'),
-            memberIds: [...range(51, 54), ...range(59, 62)],
+            memberIds: [64, ...range(51, 54), ...range(59, 62)],
           },
           {
             name: this.$t('app.groups.hololiveEnglish'),
-            memberIds: [...range(54, 59), ...range(66, 72)],
-          },
-          {
-            name: this.$t('app.groups.others'),
-            // Dummy ids are specified here to be compatible to new members
-            memberIds: [...range(62, 66), ...range(72, 82)],
+            memberIds: [65, ...range(54, 59), ...range(66, 72)],
           },
         ]
       },

--- a/src/options/components/member-group.vue
+++ b/src/options/components/member-group.vue
@@ -1,5 +1,5 @@
 <template>
-  <Fragment>
+  <Fragment v-if="groupMembers.length">
     <div class="header">
       <div class="title"><span>{{ name }}</span></div>
       <div class="select-helper">
@@ -26,7 +26,7 @@
         </transition>
       </div>
     </div>
-    <ol v-if="groupMembers.length" class="content">
+    <ol class="content">
       <li v-for="member in groupMembers" :key="member['id']" class="member-container">
         <SubscriptionInput
           :member="member"
@@ -36,7 +36,6 @@
         />
       </li>
     </ol>
-    <div v-else class="empty">{{ $t('memberGroup.noData') }}</div>
   </Fragment>
 </template>
 
@@ -278,14 +277,5 @@
         width: 100%;
       }
     }
-  }
-
-  .empty {
-    margin: 16px 0;
-    color: var(--color-text-light);
-    font-weight: 300;
-    font-style: italic;
-    font-size: 16px;
-    text-align: center;
   }
 </style>

--- a/src/options/i18n/locales/de.json5
+++ b/src/options/i18n/locales/de.json5
@@ -26,8 +26,6 @@
   },
   // Component MemberGroup
   memberGroup: {
-    // Indicate that no member data can be found for this group
-    noData: "Keine Daten zum Mitglied gefunden",
     // Help users to perform group operations when detected
     selectHelper: {
       // Prompt users to unsubscribe to all members in a group or not, with the question mark

--- a/src/options/i18n/locales/de.json5
+++ b/src/options/i18n/locales/de.json5
@@ -15,6 +15,7 @@
     },
     // Each key in 'groups' is a group defined at https://www.hololive.tv/member and the according value is the localized name of it
     groups: {
+      // This group collects the members who are newly tracked by the backend but have not been updated yet in this extension
       newDebuts: "Neue Debüts!",
       hololive: "Hololive",
       holostars: "Holostars",

--- a/src/options/i18n/locales/de.json5
+++ b/src/options/i18n/locales/de.json5
@@ -15,13 +15,13 @@
     },
     // Each key in 'groups' is a group defined at https://www.hololive.tv/member and the according value is the localized name of it
     groups: {
+      newDebuts: "Neue Debüts!",
       hololive: "Hololive",
       holostars: "Holostars",
       inonakaMusic: "INoNaKa MUSIC",
       hololiveChina: "Hololive China",
       hololiveIndonesia: "Hololive Indonesia",
-      hololiveEnglish: "Hololive English",
-      others: "Andere"
+      hololiveEnglish: "Hololive English"
     }
   },
   // Component MemberGroup

--- a/src/options/i18n/locales/en.json5
+++ b/src/options/i18n/locales/en.json5
@@ -15,6 +15,7 @@
     },
     // Each key in 'groups' is a group defined at https://www.hololive.tv/member and the according value is the localized name of it
     groups: {
+      // This group collects the members who are newly tracked by the backend but have not been updated yet in this extension
       newDebuts: "New Debuts!",
       hololive: "Hololive",
       holostars: "Holostars",

--- a/src/options/i18n/locales/en.json5
+++ b/src/options/i18n/locales/en.json5
@@ -15,13 +15,13 @@
     },
     // Each key in 'groups' is a group defined at https://www.hololive.tv/member and the according value is the localized name of it
     groups: {
+      newDebuts: "New Debuts!",
       hololive: "Hololive",
       holostars: "Holostars",
       inonakaMusic: "INoNaKa MUSIC",
       hololiveChina: "Hololive China",
       hololiveIndonesia: "Hololive Indonesia",
-      hololiveEnglish: "Hololive English",
-      others: "Others"
+      hololiveEnglish: "Hololive English"
     }
   },
   // Component MemberGroup

--- a/src/options/i18n/locales/en.json5
+++ b/src/options/i18n/locales/en.json5
@@ -26,8 +26,6 @@
   },
   // Component MemberGroup
   memberGroup: {
-    // Indicate that no member data can be found for this group
-    noData: "No Member Data",
     // Help users to perform group operations when detected
     selectHelper: {
       // Prompt users to unsubscribe to all members in a group or not, with the question mark

--- a/src/options/i18n/locales/ja.json5
+++ b/src/options/i18n/locales/ja.json5
@@ -16,7 +16,7 @@
     // Each key in 'groups' is a group defined at https://www.hololive.tv/member and the according value is the localized name of it
     groups: {
       // This group collects the members who are newly tracked by the backend but have not been updated yet in this extension
-      newDebuts: "最近のデビュー！",
+      newDebuts: "新メンバー！",
       hololive: "ホロライブ",
       holostars: "ホロスターズ",
       inonakaMusic: "イノナカミュージック",

--- a/src/options/i18n/locales/ja.json5
+++ b/src/options/i18n/locales/ja.json5
@@ -26,8 +26,6 @@
   },
   // Component MemberGroup
   memberGroup: {
-    // Indicate that no member data can be found for this group
-    noData: "メンバーのデータがありません",
     // Help users to perform group operations when detected
     selectHelper: {
       // Prompt users to unsubscribe to all members in a group or not, with the question mark

--- a/src/options/i18n/locales/ja.json5
+++ b/src/options/i18n/locales/ja.json5
@@ -15,13 +15,13 @@
     },
     // Each key in 'groups' is a group defined at https://www.hololive.tv/member and the according value is the localized name of it
     groups: {
+      newDebuts: "最近のデビュー！",
       hololive: "ホロライブ",
       holostars: "ホロスターズ",
       inonakaMusic: "イノナカミュージック",
       hololiveChina: "ホロライブ中国",
       hololiveIndonesia: "ホロライブインドネシア",
-      hololiveEnglish: "ホロライブEnglish",
-      others: "その他"
+      hololiveEnglish: "ホロライブEnglish"
     }
   },
   // Component MemberGroup

--- a/src/options/i18n/locales/ja.json5
+++ b/src/options/i18n/locales/ja.json5
@@ -15,6 +15,7 @@
     },
     // Each key in 'groups' is a group defined at https://www.hololive.tv/member and the according value is the localized name of it
     groups: {
+      // This group collects the members who are newly tracked by the backend but have not been updated yet in this extension
       newDebuts: "最近のデビュー！",
       hololive: "ホロライブ",
       holostars: "ホロスターズ",

--- a/src/options/i18n/locales/zh-CN.json5
+++ b/src/options/i18n/locales/zh-CN.json5
@@ -15,6 +15,7 @@
     },
     // Each key in 'groups' is a group defined at https://www.hololive.tv/member and the according value is the localized name of it
     groups: {
+      // This group collects the members who are newly tracked by the backend but have not been updated yet in this extension
       newDebuts: "最新出道！",
       hololive: "Hololive",
       holostars: "Holostars",

--- a/src/options/i18n/locales/zh-CN.json5
+++ b/src/options/i18n/locales/zh-CN.json5
@@ -26,8 +26,6 @@
   },
   // Component MemberGroup
   memberGroup: {
-    // Indicate that no member data can be found for this group
-    noData: "无成员数据",
     // Help users to perform group operations when detected
     selectHelper: {
       // Prompt users to unsubscribe to all members in a group or not

--- a/src/options/i18n/locales/zh-CN.json5
+++ b/src/options/i18n/locales/zh-CN.json5
@@ -15,13 +15,13 @@
     },
     // Each key in 'groups' is a group defined at https://www.hololive.tv/member and the according value is the localized name of it
     groups: {
+      newDebuts: "最新出道！",
       hololive: "Hololive",
       holostars: "Holostars",
       inonakaMusic: "INoNaKa MUSIC",
       hololiveChina: "Hololive China",
       hololiveIndonesia: "Hololive Indonesia",
-      hololiveEnglish: "Hololive English",
-      others: "其他"
+      hololiveEnglish: "Hololive English"
     }
   },
   // Component MemberGroup


### PR DESCRIPTION
This PR implements the alternative described in #97. 

* Rename member group 'Others' to 'New Debuts' and move group members into relative groups.
* Hide empty member groups.

![0](https://user-images.githubusercontent.com/23452609/132792951-51b84e8d-e76c-4996-889b-884070ecccbb.PNG)
![1](https://user-images.githubusercontent.com/23452609/132793006-a01d521a-8e32-4d91-a619-e41e75895fd9.PNG)

