### PR TITLE
Fix an auto scroll bug where there are few ended lives.

### DIFF
--- a/src/popup/components/live-list-ended.vue
+++ b/src/popup/components/live-list-ended.vue
@@ -62,7 +62,8 @@
 
       if (scrollHeightDiff === 0) {
         setTimeout(() => {
-          this.parentElement.scrollTop = (isFirstRun && this.$refs.root?.clientHeight) || 0
+          this.parentElement.scrollTop = (isFirstRun && this.$refs.root?.clientHeight)
+            || this.parentElement.scrollTop
         }, 0)
         return
       }

--- a/src/popup/components/live-list-ended.vue
+++ b/src/popup/components/live-list-ended.vue
@@ -1,5 +1,5 @@
 <template>
-  <ul v-if="lives.length" class="list">
+  <ul v-if="lives.length" ref="root" class="list">
     <template v-for="(live, index) in lives">
       <div v-if="getDateOfLive(index) !== getDateOfLive(index - 1)"
            :key="`anchor-${live['id']}`"
@@ -61,6 +61,9 @@
       const scrollHeightDiff = this.parentElement.scrollHeight - this.savedScrollHeight
 
       if (scrollHeightDiff === 0) {
+        setTimeout(() => {
+          this.parentElement.scrollTop = (isFirstRun && this.$refs.root?.clientHeight) || 0
+        }, 0)
         return
       }
 


### PR DESCRIPTION
This PR fixes #100.

* Handle cases for auto scroll where `scrollHeightDiff === 0` but the list height did changed in the first run.