### PR TITLE
Update isGuerrillaLive.

### DIFF
--- a/src/background/alarm/index.test.js
+++ b/src/background/alarm/index.test.js
@@ -579,7 +579,7 @@ test('Three current lives including a guerrilla exist during the system\'s sleep
         id: 7,
         title: 'Title 7',
         created_at: dayjs().subtract(5, 'minute').toISOString(),
-        start_at: dayjs().subtract(2, 'minute').toISOString(),
+        start_at: dayjs().subtract(4, 'minute').toISOString(),
       },
     ],
     scheduledLives: [],

--- a/src/background/utils/index.js
+++ b/src/background/utils/index.js
@@ -11,7 +11,7 @@ const getUnixBeforeDays = days => getUnixAfterDays(-days)
 const getUnix = input => dayjs(input).unix()
 
 const isGuerrillaLive = live => dayjs(live['created_at']).add(10, 'minute').isSameOrAfter(dayjs(live['start_at']))
-  && dayjs(live['start_at']).add(1, 'minute').isSameOrAfter(dayjs())
+  && dayjs(live['start_at']).add(3, 'minute').isSameOrAfter(dayjs())
 
 const uniqRightBy = (array, ...args) => reverse(uniqBy(reverse([...array]), ...args))
 

--- a/src/background/utils/index.test.js
+++ b/src/background/utils/index.test.js
@@ -47,7 +47,7 @@ test('should not be guerrila live', () => {
     created_at: dayjs().toISOString(),
   }
   const liveTwo = {
-    start_at: dayjs().subtract(2, 'minute').toISOString(),
+    start_at: dayjs().subtract(4, 'minute').toISOString(),
     created_at: dayjs().toISOString(),
   }
 


### PR DESCRIPTION
I Don't know why but a case has been observed where alarms are fired not every 1 minute but every 2 minutes instead.

This causes guerrila live detection to give a false negative.

So let's adjust the threshold for isGuerrillaLive.